### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: r
-cache:  packages


### PR DESCRIPTION
Per warning from the Travis CI build.

Found the following hidden files and directories:
  .travis.yml
These were most likely included in error. See section ‘Package
structure’ in the ‘Writing R Extensions’ manual.checking top-level files ... NOTE