### PR TITLE
PR to support LODES8 / 2020 LODES

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lehdr
 Type: Package
 Title: Grab Longitudinal Employer-Household Dynamics (LEHD) Flat Files
-Version: 1.0.2
+Version: 1.1
 Authors@R: c(person(given="Jamaal", family="Green", role = c("cre","aut"), email="jamaal.green@gmail.com"), 
     person(given="Liming", family="Wang", role =c("aut"), email="lmwang@pdx.edu"), 
     person(given="Dillon", family="Mahmoudi", role =c("aut"), email="dillonm@umbc.edu"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lehdr
 Type: Package
 Title: Grab Longitudinal Employer-Household Dynamics (LEHD) Flat Files
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(person(given="Jamaal", family="Green", role = c("cre","aut"), email="jamaal.green@gmail.com"), 
     person(given="Liming", family="Wang", role =c("aut"), email="lmwang@pdx.edu"), 
     person(given="Dillon", family="Mahmoudi", role =c("aut"), email="dillonm@umbc.edu"),
@@ -29,7 +29,7 @@ Suggests:
     devtools,
     pacman
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 URL: https://github.com/jamgreen/lehdr/
 BugReports: https://github.com/jamgreen/lehdr/issues/
 Config/testthat/edition: 3

--- a/man/grab_lodes.Rd
+++ b/man/grab_lodes.Rd
@@ -7,6 +7,7 @@
 grab_lodes(
   state,
   year,
+  version = c("LODES8", "LODES7", "LODES5"),
   lodes_type = c("od", "rac", "wac"),
   job_type = c("JT00", "JT01", "JT02", "JT03", "JT04", "JT05"),
   segment = c("S000", "SA01", "SA02", "SA03", "SE01", "SE02", "SE03", "SI01", "SI02",
@@ -21,6 +22,11 @@ grab_lodes(
 \item{state}{US state abbreviation in lower case, can be a vector of states.}
 
 \item{year}{year of the lodes data, can be a vector of years.}
+
+\item{version}{The LODES version to use.
+Version 8 (the default, use "LODES8") is enumerated at 2020 Census blocks. 
+"LODES7" is enumerated at 2010 Census blocks, but ends in 2019; 
+LODES5" is enumerated at 2000 Census blocks, but ends in 2009.}
 
 \item{lodes_type}{table type, values can be origin-destination ("od"), 
 residential association ("rac"), or workplace association ("wac"). od 

--- a/tests/testthat/test-lehdr.R
+++ b/tests/testthat/test-lehdr.R
@@ -1,44 +1,51 @@
 test_that("test grab lodes od", {
   expect_equal(grab_lodes(state = 'or', year = 2014, lodes_type = "od", job_type = "JT01", 
                           segment = "SA01", state_part = "main", agg_geo = "tract") %>% 
-                 dim, c(223119, 14))
+                 dim, c(261761, 14))
   expect_equal(grab_lodes(state = "or", year = "2015", lodes_type = "od", job_type = "JT01", 
                           segment = "SA01", state_part = "main" ) %>% 
-                 dim, c(1410831, 15))
+                 dim, c(1409076, 15))
 })
 
 test_that("test grab lodes rac", {
   expect_equal(grab_lodes(state = 'or', year = 2014, lodes_type = "rac", job_type = "JT01", 
                           segment = "SA01", agg_geo = "tract") %>% 
-                 dim, c(834, 44))
+                 dim, c(1001, 44))
   expect_equal(grab_lodes(state = "or", year = "2015", lodes_type = "rac", job_type = "JT01", 
                           segment = "SA01") %>% 
-                 dim, c(60227, 45))
+                 dim, c(57007, 45))
 })
 
 test_that("test grab lodes wac", {
   expect_equal(grab_lodes(state = 'or', year = 2014, lodes_type = "wac", job_type = "JT01", 
                           segment = "SA01", agg_geo = "tract") %>% 
-                 dim, c(825, 54))
+                 dim, c(992, 54))
   expect_equal(grab_lodes(state = "or", year = "2015", lodes_type = "wac", job_type = "JT01", 
                           segment = "SA01") %>% 
-                 dim, c(23367, 55))
+                 dim, c(23611, 55))
 })
 
 test_that("test grab lodes od for multiple states and years", {
   expect_equal(grab_lodes(state = c('or', "ri"), year = c(2013, 2014), lodes_type = "od", job_type = "JT01", 
                           segment = "SA01", state_part = "main", agg_geo = "tract") %>% 
-                 dim, c(511071, 14))
+                 dim, c(590935, 14))
   expect_equal(grab_lodes(state = c('or', "ri"), year = c(2013, 2014), lodes_type = "od", job_type = "JT01", 
                           segment = "SA01", state_part = "main" ) %>% 
-                 dim, c(3326655, 15))
+                 dim, c(3347967, 15))
 })
 
 test_that("test grab lodes wac for multiple states and years", {
   expect_equal(grab_lodes(state = c('or', "ri"), year = c(2013, 2014), lodes_type = "wac", job_type = "JT01", 
                           segment = "SA01", agg_geo = "tract") %>% 
-                 dim, c(2132, 54))
+                 dim, c(2478, 54))
   expect_equal(grab_lodes(state = c('or', "ri"), year = c(2013, 2014), lodes_type = "wac", job_type = "JT01", 
                           segment = "SA01") %>% 
-                 dim, c(55307, 55))
+                 dim, c(59718, 55))
+})
+
+
+test_that("test using LODES7 for RAC", {
+  expect_equal(grab_lodes(state = 'or', year = 2014, version = "LODES7", lodes_type = "rac", job_type = "JT01", 
+                          segment = "SA01", agg_geo = "tract") %>% 
+                 dim, c(834, 44))
 })


### PR DESCRIPTION
Hi @jamgreen @dillonma - 

This PR addresses #30 and adds support for LODES8 (2020 Census blocks) as well as LODES5 (2000 Census blocks).  The main update is a new argument in `grab_lodes()`, `version`, which supports specification of the version.  

I've updated the test suite including a test for the use of LODES7, and all tests pass.  Would you mind taking a look when you get the chance and see if this implementation fits with your approach?